### PR TITLE
fix: fix discord badge

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,6 +7,6 @@
 
 <p align="center">
   <a href="https://discord.gg/cxd58srb">
-    <img src="../discord_badge_scaled.svg">
+    <img src="https://github.com/procore-oss/.github/blob/main/discord_badge_scaled.svg?raw=true">
   </a>
 </p>


### PR DESCRIPTION
image needs to be full URL since it renders at https://github.com/procore-oss and not in the .github repo

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
