### PR TITLE
fix: dark theme image

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 # Procore Open Source
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/procore-oss/.github/blob/main/procoredarklogo.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/procore-oss/.github/blob/main/procoredarklogo.png?raw=true">
   <img alt="Procore Open Source" src="https://raw.githubusercontent.com/procore-oss/.github/main/procorelightlogo.png">
 </picture>
 


### PR DESCRIPTION
Can't use githubusercontent raw url for source media element

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
