### PR TITLE
fix: use non-expiring discord invite

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@
 </picture>
 
 <p align="center">
-  <a href="https://discord.gg/cxd58srb">
+  <a href="https://discord.gg/eD8Tet6cXW">
     <img src="https://raw.githubusercontent.com/procore-oss/.github/main/discord_badge_scaled.svg">
   </a>
 </p>


### PR DESCRIPTION
previous invite link timed out

Checklist:

* [ ] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://GitHub.com/apps/dco/)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
